### PR TITLE
Fix client logo colors in product pages "Nuestros Clientes" section

### DIFF
--- a/product-template.css
+++ b/product-template.css
@@ -1367,13 +1367,13 @@
     width: auto;
     height: auto;
     object-fit: contain;
-    opacity: 0.6;
-    filter: grayscale(100%);
+    opacity: 1;
+    filter: grayscale(0%);
     transition: var(--transition);
 }
 
 .blog-trust-section .trust-logos img:hover {
-    opacity: 1;
+    opacity: 0.8;
     filter: grayscale(0%);
     transform: scale(1.05);
 }

--- a/productos/product-template.css
+++ b/productos/product-template.css
@@ -1328,13 +1328,13 @@
     width: auto;
     height: auto;
     object-fit: contain;
-    opacity: 0.6;
-    filter: grayscale(100%);
+    opacity: 1;
+    filter: grayscale(0%);
     transition: var(--transition);
 }
 
 .blog-trust-section .trust-logos img:hover {
-    opacity: 1;
+    opacity: 0.8;
     filter: grayscale(0%);
     transform: scale(1.05);
 }


### PR DESCRIPTION
- Remove grayscale filter from client logos to display in full color
- Increase logo opacity from 60% to 100% for better visibility
- Update hover effect to provide subtle interaction feedback
- Apply fixes to both main and productos CSS template files
- Affects all 10 product pages in productos directory

🤖 Generated with [Claude Code](https://claude.ai/code)